### PR TITLE
fixing crash when copying multiple values, where some values are above/below the fold

### DIFF
--- a/Clipboard-Manager/VC/ClipboardTableVC.swift
+++ b/Clipboard-Manager/VC/ClipboardTableVC.swift
@@ -52,11 +52,17 @@ extension ClipboardTableVC {
          Return an array of the selected ClipboardTableCell-s.
          This is useful for cell UI actions across all selected cells.
          */
-        return Array(indexSet).map { (index) -> ClipboardTableCell in
-            (self.tableView.rowView(
+        var tableCellArray: [ClipboardTableCell] = []
+        for index in Array(indexSet) {
+            guard let visibleRowView = self.tableView.rowView(
                 atRow: index, makeIfNecessary: false
-            )?.view(atColumn: 0) as? ClipboardTableCell)!
+            ) else {
+                // rowView will be `nill` if row is out-of-view
+                continue
+            }
+            tableCellArray.append((visibleRowView.view(atColumn: 0) as? ClipboardTableCell)!)
         }
+        return tableCellArray
     }
 
     private func extractRowsText(filterIndices: [Int] = []) -> [ClipboardObject] {


### PR DESCRIPTION
Previously, selecting multiple values, where some had to be scrolled down for (i.e., were originally below the fold) would crash, as the application would try to invoke the flickering selection marker for cells out-of-sight. When the application would try to grab the NSTableCellView object for such cells, it only got _nill_, which invoked the error.
This commit fixes that issue, by only grabbing cells which are within sight.